### PR TITLE
fix when service data not ready yet

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,10 @@ class MiScale extends EventEmitter {
 
         scale.address = peripheral.address;
 
+        if (peripheral.advertisement.serviceData.length === 0) {
+          return;
+        }
+
         // Assume only single service is available on scale.
         scale.svcUUID = peripheral.advertisement.serviceData[0].uuid;
         scale.svcData = peripheral.advertisement.serviceData[0].data;


### PR DESCRIPTION
Hi there.  thx for you project, works like a charm 
But some times I am getting the following error message:

```sh 
{ address: '88:0f:10:8f:de:b8',
  svcUUID: '181d',
  svcData: <Buffer 02 0c 08 e0 07 0b 15 16 09 1c>,
  manufacturerData: <Buffer 57 01 88 0f 10 8f de b8>,
  isStabilized: false,
  loadRemoved: false,
  unit: 'kg',
  weight: 10.3,
  sequence: 2332 }
/Users/zork/Projects/node-xiaomi-scale/index.js:23
        scale.svcUUID = peripheral.advertisement.serviceData[0].uuid;
``` 

Here is a fix for this kind of problem, I am using `macOS` (just in case) 